### PR TITLE
Updates test projects to .NET 8

### DIFF
--- a/Futilities/Futilities.Enums.Tests/Futilities.Enums.Tests.csproj
+++ b/Futilities/Futilities.Enums.Tests/Futilities.Enums.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Futilities/Futilities.Enums.Tests/Futilities.Enums.Tests.csproj
+++ b/Futilities/Futilities.Enums.Tests/Futilities.Enums.Tests.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
     <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Futilities/Futilities.FileIO.Tests/Futilities.FileIO.Tests.csproj
+++ b/Futilities/Futilities.FileIO.Tests/Futilities.FileIO.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Futilities/Futilities.FileIO.Tests/Futilities.FileIO.Tests.csproj
+++ b/Futilities/Futilities.FileIO.Tests/Futilities.FileIO.Tests.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
     <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Futilities/Futilities.Hash.Tests/Futilities.Hash.Tests.csproj
+++ b/Futilities/Futilities.Hash.Tests/Futilities.Hash.Tests.csproj
@@ -9,9 +9,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Futilities/Futilities.Hash.Tests/Futilities.Hash.Tests.csproj
+++ b/Futilities/Futilities.Hash.Tests/Futilities.Hash.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Futilities/Futilities.Hash.Tests/HashTests.cs
+++ b/Futilities/Futilities.Hash.Tests/HashTests.cs
@@ -12,7 +12,7 @@ namespace Futilities.Hash.Tests
     public class HashTests : TestingBase
     {
         [TestMethod]
-        [TestProperty("Expected-MD5-Hash", "D3-6B-69-53-6B-9C-C1-47-03-95-E2-C3-8A-14-1F-5A")]
+        [TestProperty("Expected-MD5-Hash", "92-2C-16-B0-30-3D-C8-64-0D-E8-57-C5-31-ED-D7-2A")]
         [TestProperty("Prop1-Value", "abcdefghijklmnopqrstuvwxyz")]
         [TestProperty("Prop2-Value", "9999")]
         [TestProperty("Prop3-Value", "1/1/2001")]
@@ -32,7 +32,7 @@ namespace Futilities.Hash.Tests
         }
 
         [TestMethod]
-        [TestProperty("Expected-SHA1-Hash", "AD-4C-EE-67-96-68-21-E3-52-A4-BE-31-18-92-2C-8D-6F-A6-0F-0D")]
+        [TestProperty("Expected-SHA1-Hash", "C1-88-3B-4D-17-16-1D-E6-3C-23-47-75-F2-22-56-29-62-36-21-5C")]
         [TestProperty("Prop1-Value", "abcdefghijklmnopqrstuvwxyz")]
         [TestProperty("Prop2-Value", "9999")]
         [TestProperty("Prop3-Value", "1/1/2001")]
@@ -52,7 +52,6 @@ namespace Futilities.Hash.Tests
         }
 
         [TestMethod]
-        [TestProperty("Expected-MD5-Hash", "D3-6B-69-53-6B-9C-C1-47-03-95-E2-C3-8A-14-1F-5A")]
         [TestProperty("Prop1-Value", "abcdefghijklmnopqrstuvwxyz")]
         [TestProperty("Prop2-Value", "9999")]
         [TestProperty("Prop3-Value", "1/1/2001")]

--- a/Futilities/Futilities.Hash/Futilities.Hash.csproj
+++ b/Futilities/Futilities.Hash/Futilities.Hash.csproj
@@ -10,4 +10,8 @@
     <ProjectReference Include="..\Futilities.Shared\Futilities.Shared.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
+  </ItemGroup>
+
 </Project>

--- a/Futilities/Futilities.ListExtensions.Tests/Futilities.ListExtensions.Tests.csproj
+++ b/Futilities/Futilities.ListExtensions.Tests/Futilities.ListExtensions.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Futilities/Futilities.ListExtensions.Tests/Futilities.ListExtensions.Tests.csproj
+++ b/Futilities/Futilities.ListExtensions.Tests/Futilities.ListExtensions.Tests.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
     <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Futilities/Futilities.ObjectExtensions.Tests/Futilities.ObjectExtensions.Tests.csproj
+++ b/Futilities/Futilities.ObjectExtensions.Tests/Futilities.ObjectExtensions.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Futilities/Futilities.ObjectExtensions.Tests/Futilities.ObjectExtensions.Tests.csproj
+++ b/Futilities/Futilities.ObjectExtensions.Tests/Futilities.ObjectExtensions.Tests.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
     <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Futilities/Futilities.StringConversion.Tests/Futilities.StringConversion.Tests.csproj
+++ b/Futilities/Futilities.StringConversion.Tests/Futilities.StringConversion.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Futilities/Futilities.StringConversion.Tests/Futilities.StringConversion.Tests.csproj
+++ b/Futilities/Futilities.StringConversion.Tests/Futilities.StringConversion.Tests.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Futilities/Futilities.StringParsing.Tests/Futilities.StringParsing.Tests.csproj
+++ b/Futilities/Futilities.StringParsing.Tests/Futilities.StringParsing.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Futilities/Futilities.StringParsing.Tests/Futilities.StringParsing.Tests.csproj
+++ b/Futilities/Futilities.StringParsing.Tests/Futilities.StringParsing.Tests.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
     <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Futilities/Futilities.Testing/Futilities.Testing.csproj
+++ b/Futilities/Futilities.Testing/Futilities.Testing.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Futilities/Futilities.Testing/Futilities.Testing.csproj
+++ b/Futilities/Futilities.Testing/Futilities.Testing.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
   </ItemGroup>
 
 </Project>

--- a/Futilities/Futilities.XmlExtensions.Tests/Futilities.XmlExtensions.Tests.csproj
+++ b/Futilities/Futilities.XmlExtensions.Tests/Futilities.XmlExtensions.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Futilities/Futilities.XmlExtensions.Tests/Futilities.XmlExtensions.Tests.csproj
+++ b/Futilities/Futilities.XmlExtensions.Tests/Futilities.XmlExtensions.Tests.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
     <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Futilities/build.yaml
+++ b/Futilities/build.yaml
@@ -43,7 +43,7 @@ jobs:
     inputs:
       command: 'pack'
       packagesToPack: '**/Futilities.Outright.csproj'
-      nobuild: true
+      nobuild: false
       includesymbols: true
       includesource: true
       versioningScheme: 'byBuildNumber'


### PR DESCRIPTION
- Updated test projects to .NET 8
- Updated vulnerable NuGet packages
- Changed `Futilities.Hash` project to not use `BinaryFormatter` anymore, [as per Microsoft's guidance](https://learn.microsoft.com/en-us/dotnet/standard/serialization/binaryformatter-migration-guide/)
- Fixed `Futilities.Hash` tests using incorrect "Expected" hash

Fixes #43 #44 